### PR TITLE
Fixes #14

### DIFF
--- a/src/core/gapi.js
+++ b/src/core/gapi.js
@@ -168,9 +168,13 @@ export default class GAPI {
     return this._libraryInit('auth2')
       .then(auth => {
         if (auth.isSignedIn.get()) {
-          auth.disconnect()
+          return auth.disconnect()
+            .then(() => {
+              return Promise.resolve()
+            })
+        } else {
+          return Promise.resolve()
         }
-        return Promise.resolve()
       })
   }
 


### PR DESCRIPTION
Changes the `signOut` method to wait for [GoogleAuth.disconnect](https://developers.google.com/identity/sign-in/web/reference#googleauthdisconnect) to resolve before resolving itself. This fixes the bug where calling `isSignedIn` immediately after awaiting `signOut` would return true.